### PR TITLE
feat: Enable MSI for aks cluster

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -70,6 +70,15 @@ resource "random_pet" "domain_name" {
   }
 }
 
+resource "random_pet" "msi_name" {
+  prefix    = "msi-aks"
+  separator = "-"
+  keepers = {
+    # Keep the name consistent on executions
+    msi_name = var.msi_name
+  }
+}
+
 locals {
   cluster_name           = var.cluster_name != "" ? var.cluster_name : random_pet.cluster.id
   node_count             = var.node_count != "" ? var.node_count : 1
@@ -85,4 +94,5 @@ locals {
   subnet_name            = var.subnet_name != "" ? var.subnet_name : random_pet.subnet_name.id
   dns_resource_group     = var.dns_resource_group != "" ? var.dns_resource_group : random_pet.dns_resource_group.id
   domain_name            = var.domain_name != "" ? var.domain_name : random_pet.domain_name.id
+  msi_name               = var.msi_name != "" ? var.msi_name : random_pet.msi_name.id
 }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,6 @@ provider "kubernetes" {
     module.cluster.client_key,
   )
 }
-
 // ----------------------------------------------------------------------------
 // Setup Azure Resource Groups
 // ----------------------------------------------------------------------------
@@ -45,7 +44,6 @@ resource "azurerm_resource_group" "cluster" {
 }
 
 resource "azurerm_resource_group" "dns" {
-  count    = var.external_dns_enabled ? 1 : 0
   name     = local.dns_resource_group
   location = local.location
 }
@@ -67,6 +65,7 @@ module "cluster" {
   resource_group_name    = azurerm_resource_group.cluster.name
   network_resource_group = local.network_resource_group
   jenkins_x_namespace    = var.jenkins_x_namespace
+  msi_name               = local.msi_name
 }
 
 // ----------------------------------------------------------------------------
@@ -89,7 +88,7 @@ module "vnet" {
 
 module "dns" {
   source                   = "./modules/dns"
-  resource_group_name      = azurerm_resource_group.dns[0].name
+  resource_group_name      = azurerm_resource_group.dns.name
   apex_resource_group_name = var.apex_domain_resource_group_name
   apex_domain              = var.apex_domain
   domain_name              = local.domain_name

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -23,11 +23,68 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   role_based_access_control {
     enabled = true
-
-    azure_active_directory {
-      managed = true
-    }
   }
+}
+
+resource "azurerm_user_assigned_identity" "mi" {
+  name                = var.msi_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+}
+
+provider "helm" {
+  kubernetes {
+    load_config_file       = true
+    host                   = azurerm_kubernetes_cluster.aks.kube_config.0.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate)
+  }
+}
+
+resource "helm_release" "aad_pod_id" {
+  name             = "aad-pod-identity"
+  repository       = "https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts"
+  chart            = "aad-pod-identity"
+  version          = "2.0.0"
+  namespace        = var.aad_pod_id_ns
+  create_namespace = true
+
+  values = [
+    <<-EOF
+    azureIdentities:
+    - name: "${azurerm_user_assigned_identity.mi.name}"
+      resourceID: "${azurerm_user_assigned_identity.mi.id}"
+      clientID: "${azurerm_user_assigned_identity.mi.client_id}"
+      binding:
+        name: "${azurerm_user_assigned_identity.mi.name}-identity-binding"
+        selector: "${var.aad_pod_id_binding_selector}"
+    EOF
+  ]
+}
+
+data "azurerm_resource_group" "aks_node_rg" {
+  name = azurerm_kubernetes_cluster.aks.node_resource_group
+}
+
+# Following roles are required by AAD Pod Identity and must be assigned to the Kubelet Identity
+# https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.msi.md#pre-requisites---role-assignments
+resource "azurerm_role_assignment" "vm_contributor" {
+  scope                = data.azurerm_resource_group.aks_node_rg.id
+  role_definition_name = "Virtual Machine Contributor"
+  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity.0.object_id
+}
+
+resource "azurerm_role_assignment" "all_mi_operator" {
+  scope                = data.azurerm_resource_group.aks_node_rg.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity.0.object_id
+}
+
+resource "azurerm_role_assignment" "mi_operator" {
+  scope                = azurerm_user_assigned_identity.mi.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity.0.object_id
 }
 
 resource "kubernetes_namespace" "jenkins_x_namespace" {

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -2,14 +2,17 @@ output "fqdn" {
   value = azurerm_kubernetes_cluster.aks.fqdn
 }
 output "cluster_endpoint" {
-  value = azurerm_kubernetes_cluster.aks.kube_admin_config.0.host
+  value = azurerm_kubernetes_cluster.aks.kube_config.0.host
 }
 output "client_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_admin_config.0.client_certificate
+  value = azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate
 }
 output "client_key" {
-  value = azurerm_kubernetes_cluster.aks.kube_admin_config.0.client_key
+  value = azurerm_kubernetes_cluster.aks.kube_config.0.client_key
 }
 output "cluster_ca_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_admin_config.0.cluster_ca_certificate
+  value = azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate
+}
+output aad_pod_id_binding_selector {
+  value = var.aad_pod_id_binding_selector
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -26,6 +26,17 @@ variable "resource_group_name" {
 variable "network_resource_group" {
   type = string
 }
+variable "msi_name" {
+  type = string
+}
+variable "aad_pod_id_ns" {
+  type    = string
+  default = "aad-pod-id"
+}
+variable "aad_pod_id_binding_selector" {
+  type    = string
+  default = "aad-pod-id-binding-selector"
+}
 variable "jenkins_x_namespace" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,9 @@ variable "apex_domain" {
 variable "domain_name" {
   type = string
 }
+variable "msi_name" {
+  type = string
+}
 variable "external_dns_enabled" {
   type    = bool
   default = false


### PR DESCRIPTION
In this PR:

- Enable MSI for ask cluster
- install aad-pod-identity helm to assign the user identity we created to the ask
- create role assignments for aks node

Fixes #4  