### PR TITLE
Add output cluster_node_resource_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The following sections provide a full list of configuration in- and output varia
 |------|-------------|
 | cluster\_fqdn | The FQDN of the created cluster |
 | cluster\_name | The name of the created cluster |
+| cluster\_node\_resource\_group | Resource group name that contains AKS VMs |
 | cluster\_resource\_group | Resource group name that contains AKS managed cluster |
 | connect | Command to run to connect to AKS cluster (downloads kube config) |
 | container\_registry\_name | The name of the Azure Container Registry that was created |

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,9 @@ output "network_resource_group" {
 output "cluster_resource_group" {
   value = local.cluster_resource_group
 }
+output "cluster_node_resource_group" {
+  value = local.cluster_node_resource_group
+}
 output "network_name" {
   value = local.network_name
 }


### PR DESCRIPTION
This PR outputs the name of the "Nodes" resource group that hosts the VMs.

There's also an update to the docs. Just a note, it looks like the output and maybe inputs are a bit out of date.